### PR TITLE
Back forward search

### DIFF
--- a/js/data-desk-search.js
+++ b/js/data-desk-search.js
@@ -119,6 +119,7 @@ $(function() {
 
       self.searchMoreURL = self.searchMoreUrlTemplate.replace("{0}", escapedQuery);
       self.q = query;
+
       self.hint = self.makeHint(query);
 
       $.ajax(url)
@@ -174,13 +175,9 @@ $(function() {
 
   var resultsContainer = $('#corporate-data-search .search-results');
   var datasetTemplate = Handlebars.compile($('#search-dataset-template').html());
-
-  $("#corporate-data-search form").on('submit', function(e) {
-    e.preventDefault();
-
-    var q = $(this).find('[name=q]').val(),
-        perCol = Math.ceil(datasets.length / 2);
-
+  var queryInput = $(this).find('[name=q]');
+  var startSearch = function(q) {
+    var perCol = Math.ceil(datasets.length / 2);
     resultsContainer
       .show()
       .find('.panel').remove();
@@ -198,8 +195,22 @@ $(function() {
           $output.find("#" + dataset.id).replaceWith(datasetTemplate(dataset));
         });
     });
+  };
 
+  $("#corporate-data-search form").on('submit', function(e) {
+    e.preventDefault();
+    var q = queryInput.val();
+    history.pushState(q, "page 2", "trace.html?q=" + q);
+    startSearch(q);
     if ('ga' in window) ga('send', 'event', 'corporate-data-search', 'request', q);
   });
+
+  window.onpopstate = function(event) {
+    if (event.state) {
+      var q = event.state;
+      queryInput.val(q);
+      startSearch(q);
+    }
+  }
 
 });

--- a/js/data-desk-search.js
+++ b/js/data-desk-search.js
@@ -200,7 +200,8 @@ $(function() {
   $("#corporate-data-search form").on('submit', function(e) {
     e.preventDefault();
     var q = queryInput.val();
-    history.pushState(q, "TRACE search: " + q, "trace.html?q=" + q);
+    if ('pushState' in history)
+      history.pushState(q, "TRACE search: " + q, "trace.html?q=" + encodeURIComponent(q));
     startSearch(q);
     if ('ga' in window) ga('send', 'event', 'corporate-data-search', 'request', q);
   });

--- a/js/data-desk-search.js
+++ b/js/data-desk-search.js
@@ -200,7 +200,7 @@ $(function() {
   $("#corporate-data-search form").on('submit', function(e) {
     e.preventDefault();
     var q = queryInput.val();
-    history.pushState(q, "page 2", "trace.html?q=" + q);
+    history.pushState(q, "TRACE search: " + q, "trace.html?q=" + q);
     startSearch(q);
     if ('ga' in window) ga('send', 'event', 'corporate-data-search', 'request', q);
   });


### PR DESCRIPTION
push browser history upon trace search so that you can click back to go back to your previous search.

repeats previous search and assumes it's cheap, leveraging caching by the search providers. therefore wont work if connection was lost.